### PR TITLE
NetFunnel 관련 에러 발생시 자동으로 재시도 로직 작성.

### DIFF
--- a/srtgo/srtgo.py
+++ b/srtgo/srtgo.py
@@ -290,7 +290,7 @@ def get_options():
 def set_misc_options():
     """기타 설정 관리 함수"""
     current_netfunnel_retry = keyring.get_password("SRT", "netfunnel_auto_retry") == "1"
-    
+
     choices = inquirer.prompt(
         [
             inquirer.Confirm(
@@ -300,18 +300,18 @@ def set_misc_options():
             )
         ]
     )
-    
+
     if choices is None:
         return
-    
+
     # NetFunnel 자동 재시도 설정 저장
     keyring.set_password(
-        "SRT", 
-        "netfunnel_auto_retry", 
-        "1" if choices["netfunnel_auto_retry"] else "0"
+        "SRT", "netfunnel_auto_retry", "1" if choices["netfunnel_auto_retry"] else "0"
     )
-    
-    print(f"NetFunnelError 자동 재시도: {'활성화' if choices['netfunnel_auto_retry'] else '비활성화'}")
+
+    print(
+        f"NetFunnelError 자동 재시도: {'활성화' if choices['netfunnel_auto_retry'] else '비활성화'}"
+    )
 
 
 def get_netfunnel_auto_retry():
@@ -741,6 +741,16 @@ def reserve(rail_type="SRT", debug=False):
                     return
             _sleep()
 
+        except (SRTNetFunnelError, KTXNetFunnelError) as ex:
+            # NetFunnel 자동 재시도 설정이 켜져있을 때만 처리
+            if get_netfunnel_auto_retry():
+                print("\n대기열 연결 시간 초과. 자동 재시도 중...")
+                _sleep()
+                rail = login(rail_type, debug=debug)
+            else:
+                # 자동 재시도가 꺼져있으면 다시 raise하여 일반 Exception 핸들러에서 처리
+                raise ex
+
         except SRTError as ex:
             msg = ex.msg
             if "정상적인 경로로 접근 부탁드립니다" in msg:
@@ -769,16 +779,6 @@ def reserve(rail_type="SRT", debug=False):
                 if not _handle_error(ex):
                     return
             _sleep()
-
-        except (SRTNetFunnelError, KTXNetFunnelError) as ex:
-            # NetFunnel 자동 재시도 설정이 켜져있을 때만 처리
-            if get_netfunnel_auto_retry():
-                print("\n대기열 연결 시간 초과. 자동 재시도 중...")
-                _sleep()
-                rail = login(rail_type, debug=debug)
-            else:
-                # 자동 재시도가 꺼져있으면 다시 raise하여 일반 Exception 핸들러에서 처리
-                raise
 
         except KorailError as ex:
             if not any(

--- a/srtgo/srtgo.py
+++ b/srtgo/srtgo.py
@@ -773,10 +773,6 @@ def reserve(rail_type="SRT", debug=False):
         except (SRTNetFunnelError, KTXNetFunnelError) as ex:
             # NetFunnel 자동 재시도 설정이 켜져있을 때만 처리
             if get_netfunnel_auto_retry():
-                if debug:
-                    print(
-                        f"\nException: {ex}\nType: {type(ex)}\nMessage: {ex.msg if hasattr(ex, 'msg') else str(ex)}"
-                    )
                 print("\n대기열 연결 시간 초과. 자동 재시도 중...")
                 _sleep()
                 rail = login(rail_type, debug=debug)


### PR DESCRIPTION
안녕하세요.
만들어주신 패키지 잘 쓰고 있습니다.

보통 SRT표가 빠르게 매진되어서,
취소표를 잡기 위해 해당 패키지를 활용하고 있습니다!
그러면 보통 엄청나게 긴 대기시간을 가지고 몇시간 동안 스크립트를 돌리게 되는데
종종 NetFunnelError가 나서 스크립트를 직접 재실행해줘야하는 번거로움이 있습니다.

```
예매 대기 중... | 1320 (00:36:23)
Exception: Failed to perform, curl: (28) Connection timed out after 30002 milliseconds. See https://curl.se/libcurl/c/libcurl-errors.html first for more details., Type: <class 'srtgo.srt.SRTNetFunnelError'>, Message: Failed to perform, curl: (28) Connection timed out after 30002 milliseconds. See https://curl.se/libcurl/c/libcurl-errors.html first for more details.
[?] 계속할까요 (Y/n): y

예매 대기 중... - 1470 (00:46:33)
Exception: Failed to perform, curl: (28) Connection timed out after 30002 milliseconds. See https://curl.se/libcurl/c/libcurl-errors.html first for more details., Type: <class 'srtgo.srt.SRTNetFunnelError'>, Message: Failed to perform, curl: (28) Connection timed out after 30002 milliseconds. See https://curl.se/libcurl/c/libcurl-errors.html first for more details.
[?] 계속할까요 (Y/n): y

예매 대기 중... / 2037 (01:04:29)
Exception: Failed to perform, curl: (28) Connection timed out after 30002 milliseconds. See https://curl.se/libcurl/c/libcurl-errors.html first for more details., Type: <class 'srtgo.srt.SRTNetFunnelError'>, Message: Failed to perform, curl: (28) Connection timed out after 30002 milliseconds. See https://curl.se/libcurl/c/libcurl-errors.html first for more details.
[?] 계속할까요 (Y/n): y
....
(무한반복)
```

그래서, 해당 에러가 발생하면 해당 에러를 무시하고 자동으로 다시 재실행하는 옵션을 넣어봤습니다.
![image](https://github.com/user-attachments/assets/03a069ef-2d01-4172-be39-2c0f90b051d4)

옵션을 저장 하는 방식은 기존과 동일하게 키체인으로 처리했고
rail_type은 받을까 하다가 위쪽에 rail_type없이 SRT에 저장하는 로직이 있길래 비슷하게 작성해봤습니다.
해당 옵션을 켜면 SRTNetFunnelError, NetFunnelError(KTXNetFunnelError) Exception에 대해 자동으로 다시 시도하게끔 작성했습니다.

사실 NetFunnel을 아예 우회하는 방식으로 작성하고 싶었는데,
해당 방식은 프로세스가 많아지면 뭔가 법적으로 문제가 있을수도 있을것 같아서 일단 해당 방식으로 작성했습니다.

다시 한번 좋은 패키지 공유에 감사드립니다.
(텔레그램 알림 기능 최고!!)