### PR TITLE
feat: SRT/KTX 1개월 전 07시 기준 날짜 선택

### DIFF
--- a/srtgo/srtgo.py
+++ b/srtgo/srtgo.py
@@ -480,13 +480,25 @@ def reserve(rail_type="SRT", debug=False):
     stations, station_key = get_station(rail_type)
     options = get_options()
 
-    # Generate date and time choices
+    # Calculate dynamic booking window (SRT: D-30, KTX: D-31; both open at 07:00)
+    current = datetime.now()
+    if is_srt:
+        max_days = 30 if current.hour >= 7 else 29
+    else:
+        max_days = 31 if current.hour >= 7 else 30
+    last_bookable_date = (current + timedelta(days=max_days)).date()
+    base_date = now.date()
+    max_i = (last_bookable_date - base_date).days
+    if max_i < 0:
+        max_i = 0
+
+    # Generate date choices within the window (0 ~ max_i, inclusive)
     date_choices = [
         (
-            (now + timedelta(days=i)).strftime("%Y/%m/%d %a"),
-            (now + timedelta(days=i)).strftime("%Y%m%d"),
+            (base_date + timedelta(days=i)).strftime("%Y/%m/%d %a"),
+            (base_date + timedelta(days=i)).strftime("%Y%m%d"),
         )
-        for i in range(28)
+        for i in range(max_i + 1)
     ]
     time_choices = [(f"{h:02d}", f"{h:02d}0000") for h in range(24)]
 

--- a/srtgo/srtgo.py
+++ b/srtgo/srtgo.py
@@ -481,24 +481,18 @@ def reserve(rail_type="SRT", debug=False):
     options = get_options()
 
     # Calculate dynamic booking window (SRT: D-30, KTX: D-31; both open at 07:00)
-    current = datetime.now()
     if is_srt:
-        max_days = 30 if current.hour >= 7 else 29
+        max_days = 30 if now.hour >= 7 else 29
     else:
-        max_days = 31 if current.hour >= 7 else 30
-    last_bookable_date = (current + timedelta(days=max_days)).date()
-    base_date = now.date()
-    max_i = (last_bookable_date - base_date).days
-    if max_i < 0:
-        max_i = 0
+        max_days = 31 if now.hour >= 7 else 30
 
-    # Generate date choices within the window (0 ~ max_i, inclusive)
+    # Generate date choices within the window
     date_choices = [
         (
-            (base_date + timedelta(days=i)).strftime("%Y/%m/%d %a"),
-            (base_date + timedelta(days=i)).strftime("%Y%m%d"),
+            (now + timedelta(days=i)).strftime("%Y/%m/%d %a"),
+            (now + timedelta(days=i)).strftime("%Y%m%d"),
         )
-        for i in range(max_i + 1)
+        for i in range(max_days + 1)
     ]
     time_choices = [(f"{h:02d}", f"{h:02d}0000") for h in range(24)]
 


### PR DESCRIPTION
예약 화면의 날짜 선택을 고정 28일에서 동적으로 변경하였습니다.
SRT는 D-30, KTX는 D-31 기준이며, 두 경우 모두 07:00에 오픈하도록 반영했습니다.

[![KTX](https://github.com/user-attachments/assets/daae33ba-ef2d-44a3-8e26-eda17b767f65)](https://info.korail.com/info/selectBbsNttList.do;jsessionid=vtGYymt9RoaYjB3oNWU4J6aCZ1taND30dNkyApMebTGCpMCKljUG4VMPeD0rRIrh?key=817&bbsNo=205&searchCtgry=&searchCnd=all&searchKrwd=&integrDeptCode=&pageIndex=8)
*KTX*

[![SRT](https://github.com/user-attachments/assets/22a35ab9-337a-4262-9e1b-060f0f507841)](https://etk.srail.kr/cms/archive.do?pageId=TK0402010000)
*SRT*
